### PR TITLE
Changes for CI/CD workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Build image
       run: |
-        docker build . --tag docker.pkg.github.com/vkuznet/ruciotracers
+        docker build . --tag docker.pkg.github.com/dmwm/ruciotracers
 
     - name: Login to docker github registry
       uses: docker/login-action@v1.6.0
@@ -78,20 +78,20 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com
-        repository: vkuznet/RucioTracers/RucioTracers
+        repository: dmwm/ruciotracers/ruciotracers
         tag_with_ref: true
 
-#     - name: Login to DockerHub
-#       uses: docker/login-action@v1
-#       with:
-#         username: ${{ secrets.DOCKER_HUB_USERNAME }}
-#         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_HUB_USERNAME }}
+        password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
-#     - name: Build and push
-#       uses: docker/build-push-action@v2
-#       with:
-#         context: .
-#         file: ./Dockerfile
-#         load: true
-#         tags: cmssw/RucioTracers:${{steps.get-ref.outputs.tag}}
-#     - run: docker push cmssw/RucioTracers:${{steps.get-ref.outputs.tag}}
+    - name: Build and push
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        load: true
+        tags: cmssw/ruciotracers:${{steps.get-ref.outputs.tag}}
+    - run: docker push cmssw/ruciotracers:${{steps.get-ref.outputs.tag}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Build image
       run: |
-        docker build . --tag docker.pkg.github.com/dmwm/RucioTracers
+        docker build . --tag docker.pkg.github.com/vkuznet/ruciotracers
 
     - name: Login to docker github registry
       uses: docker/login-action@v1.6.0
@@ -78,7 +78,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com
-        repository: dmwm/RucioTracers/RucioTracers
+        repository: vkuznet/RucioTracers/RucioTracers
         tag_with_ref: true
 
 #     - name: Login to DockerHub

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
     - name: Build image
       run: |
-        docker build . --tag docker.pkg.github.com/dmwm/ruciotracers
+        docker build . --tag docker.pkg.github.com/dmwm/rucio-tracers
 
     - name: Login to docker github registry
       uses: docker/login-action@v1.6.0
@@ -78,7 +78,7 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: docker.pkg.github.com
-        repository: dmwm/ruciotracers/ruciotracers
+        repository: dmwm/rucio-tracers/rucio-tracers
         tag_with_ref: true
 
     - name: Login to DockerHub
@@ -93,5 +93,5 @@ jobs:
         context: .
         file: ./Dockerfile
         load: true
-        tags: cmssw/ruciotracers:${{steps.get-ref.outputs.tag}}
-    - run: docker push cmssw/ruciotracers:${{steps.get-ref.outputs.tag}}
+        tags: cmssw/rucio-tracers:${{steps.get-ref.outputs.tag}}
+    - run: docker push cmssw/rucio-tracers:${{steps.get-ref.outputs.tag}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,7 +3,7 @@ name: Build
 on:
   push:
     tags:
-      - '*.*.*'
+      - '*'
   workflow_dispatch:
     inputs:
       logLevel:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,9 +4,16 @@ on:
   push:
     tags:
       - '*.*.*'
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+      tags:
+        description: 'Test scenario tags'
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
@@ -57,7 +64,7 @@ jobs:
     - name: Build image
       run: |
         docker build . --tag docker.pkg.github.com/dmwm/RucioTracers
-      
+
     - name: Login to docker github registry
       uses: docker/login-action@v1.6.0
       with:


### PR DESCRIPTION
I tested this workflow locally using my docker/github accounts. It contains few changes:
- add workflow_dispatch which allows to manually run it in Github action
- change repo name to match dmwm
- uncomment blocks for docker hub uploads (requires proper dmwmbot credentials in place)