### PR TITLE
Add CERN registry workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,23 @@ jobs:
     - name: Build image
       run: |
         docker build . --tag docker.pkg.github.com/dmwm/rucio-tracers
+        docker tag docker.pkg.github.com/dmwm/rucio-tracers/rucio-tracers registry.cern.ch/cmsweb/rucio-tracers
+
+    - name: Login to registry.cern.ch
+      uses: docker/login-action@v1.6.0
+      with:
+        registry: registry.cern.ch
+        username: ${{ secrets.CERN_LOGIN }}
+        password: ${{ secrets.CERN_TOKEN }}
+
+    - name: Publish image to registry.cern.ch
+      uses: docker/build-push-action@v1
+      with:
+        username: ${{ secrets.CERN_LOGIN }}
+        password: ${{ secrets.CERN_TOKEN }}
+        registry: registry.cern.ch
+        repository: cmsweb/rucio-tracers
+        tag_with_ref: true
 
     - name: Login to docker github registry
       uses: docker/login-action@v1.6.0


### PR DESCRIPTION
New changes allow to build and push image to CERN registry.

@yuyiguo it is transparent changes and only required for build. The new image will be build and pushed to CERN registry which is a new repository for our cmsweb images to use (instead of docker hub).